### PR TITLE
Raise value error on cell that hasn't been run yet and some extra tests.

### DIFF
--- a/nbsafety/safety.py
+++ b/nbsafety/safety.py
@@ -413,6 +413,9 @@ class NotebookSafety(singletons.NotebookSafety):
             - dict (int, str): map from required cell number to code
                 representing dependencies
         """
+        if cell_num not in self.cell_content_by_counter.keys():
+            raise ValueError(f'Cell {cell_num} has not been run yet.')
+
         dependencies: Set[int] = set()
         cell_num_to_dynamic_deps: Dict[int, Set[int]] = defaultdict(set)
         for sym in self.all_data_symbols():

--- a/test/test_dynamic_slicing.py
+++ b/test/test_dynamic_slicing.py
@@ -64,3 +64,22 @@ def test_list_mutations():
     run_cell('logging.info(lst)')
     deps = set(nbs().get_cell_dependencies(5).keys())
     assert deps == {2, 3, 4, 5}, 'got %s' % deps
+
+
+def test_imports():
+    run_cell('import numpy as np')
+    run_cell('arr = np.zeros((5,))')
+    run_cell('print(arr * 3)')
+    deps = set(nbs().get_cell_dependencies(3).keys())
+    assert deps == {1, 2, 3}, 'got %s' % deps
+
+
+@skipif_known_failing
+def test_handle_stale():
+    run_cell('a = 1')
+    run_cell('b = 2 * a')
+    run_cell('a = 2')
+    run_cell('print(b)')
+    run_cell('print(b)')
+    deps = set(nbs().get_cell_dependencies(4).keys())
+    assert deps == {1, 2, 4}, 'got %s' % deps


### PR DESCRIPTION
This PR accomplishes the following:

1. Raises `ValueError` when calling `get_dependencies` on a cell number that hasn't been run yet.
2. Adds a test importing `numpy` (passes).
3. Adds a test trying to rerun a cell knowing there is a stale reference (fails.)
<img width="442" alt="Screen Shot 2021-04-09 at 1 31 20 PM" src="https://user-images.githubusercontent.com/6224969/114237863-4a1cdd00-9949-11eb-82c6-ed9b42c5399b.png">
